### PR TITLE
A proposed fix for #4.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function (file, condition) {
 		if (!conditions.length) {
 			throw new Error('gulp-match: empty glob array');
 		}
-		var i = 0, step, ret = false;
+		var i, step, ret = false;
 		var hasNonNegate = conditions.some(function(expression) {
 			return expression && expression[0] !== '!';
 		});

--- a/index.js
+++ b/index.js
@@ -31,13 +31,22 @@ module.exports = function (file, condition) {
 	}
 
 	if (Array.isArray(condition)) {
+		// Copy the array as we may modify it later.
+		var conditions = condition.slice(0);
+
 		// FRAGILE: ASSUME: it's a minimatch expression
-		if (!condition.length) {
+		if (!conditions.length) {
 			throw new Error('gulp-match: empty glob array');
 		}
 		var i = 0, step, ret = false;
-		for (i = 0; i < condition.length; i++) {
-			step = condition[i];
+		var hasNonNegate = conditions.some(function(expression) {
+			return expression && expression[0] !== '!';
+		});
+		if (!hasNonNegate) {
+			conditions.push('**/*');
+		}
+		for (i = 0; i < conditions.length; i++) {
+			step = conditions[i];
 			if (step[0] === '!') {
 				if (minimatch(file.path, step.slice(1))) {
 					return false;

--- a/test/array.js
+++ b/test/array.js
@@ -69,6 +69,22 @@ describe('gulp-match', function() {
 			multiPatternTest('.jshintrc', false);
 			multiPatternTest('app.js', true);
 		});
+		var singlePatternTest = function(file, expected) {
+			// arrange
+			var pattern = ['!*.css'];
+
+			// act
+			var actual = gulpmatch({path:file}, pattern);
+
+			// assert
+			actual.should.equal(expected);
+
+
+		};
+		it('should filter files with a single negate pattern', function() {
+			singlePatternTest('excluded.css', false);
+			singlePatternTest('included.js', true);
+		});
 
 	});
 });


### PR DESCRIPTION
Here is my proposed fix for when you specify an array of minimatch expressions, when none of them include a non-negate expression.

This should continue to respect the default values that gulpmatch use (e.g. the "dot" option).
