### PR TITLE
Update Travis to run supported Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "5"
-  - "stable"
+  - "0.12"  # Supported till 2016-12-31
+  - "4"     # Supported till 2018-04-01
+  - "6"     # Supported till 2019-04-18
+  - "7"     # Active Development


### PR DESCRIPTION
0.10 ran out of LTS on 10-31
5 is no longer supported once 6 went LTS and 7 was released
Add 7 as it's the current version under active development
 Remove "stable" as per the nvm docs it's now deprecated.

I also added notes about when support runs out on each version.